### PR TITLE
Update call to deprecated function

### DIFF
--- a/pytest_subtesthack.py
+++ b/pytest_subtesthack.py
@@ -6,11 +6,18 @@ from _pytest.python import Function
 def subtest(request):
     parent_test = request.node
     def inner(func):
-        item = Function(
-            name=request.function.__name__ + '[]',
-            parent=parent_test.parent,
-            callobj=func,
-        )
+        if hasattr(Function, "from_parent"):
+            item = Function.from_parent(
+                parent_test.parent,
+                name=request.function.__name__ + '[]',
+            )
+            item.callobj=func
+        else:
+            item = Function(
+                name=request.function.__name__ + '[]',
+                parent=parent_test.parent,
+                callobj=func
+            )
         nextitem = parent_test  # prevents pytest from tearing down module fixtures
 
         item.ihook.pytest_runtest_setup(item=item)


### PR DESCRIPTION
This is no longer supported by pytest:

> Failed: Direct construction of Function has been deprecated, please use Function.from_parent.
> See https://docs.pytest.org/en/stable/deprecations.html#node-construction-changed-to-node-from-parent for more details.