### PR TITLE
Teardown function node on test failure

### DIFF
--- a/pytest_subtesthack.py
+++ b/pytest_subtesthack.py
@@ -22,8 +22,10 @@ def subtest(request):
         nextitem = parent_test  # prevents pytest from tearing down module fixtures
 
         item.ihook.pytest_runtest_setup(item=item)
-        item.ihook.pytest_runtest_call(item=item)
-        item.ihook.pytest_runtest_teardown(item=item, nextitem=nextitem)
+        try:
+            item.ihook.pytest_runtest_call(item=item)
+        finally:
+            item.ihook.pytest_runtest_teardown(item=item, nextitem=nextitem)
 
 
 


### PR DESCRIPTION
Without it, it causes this internal pytest assertion on all hypothesis
runs but the first:

```
>           assert col in needed_collectors, "previous item was not torn down properly"
E           AssertionError: previous item was not torn down properly

../../.local/lib/python3.9/site-packages/_pytest/runner.py:482: AssertionError
```

which then causes hypothesis to mark the test as flaky and mangle the
output, making the original assertion invisible